### PR TITLE
conode/Dockerfile* improvement

### DIFF
--- a/conode/Dockerfile
+++ b/conode/Dockerfile
@@ -1,19 +1,19 @@
-FROM golang:1.10 as builder
-ARG BUILDFLAG="-s -w -X main.gitTag=unknown github.com/dedis/onet.gitTag=unknown"
-RUN apt-get update && apt-get install -y clang
-RUN go get github.com/dedis/cothority
-RUN cd /go/src/github.com/dedis/cothority/conode && go get -u ./...
-RUN cd /go/src/github.com/dedis/cothority/conode && go install -ldflags="$BUILDFLAG" .
+FROM golang:1.12 as builder
+ARG BUILD_TAG=none
+ARG ldflags="-s -w -X main.gitTag=unknown"
+RUN go get go.dedis.ch/cothority
+RUN cd /go/src/go.dedis.ch/cothority && git checkout $BUILD_TAG && GO111MODULE=on go install -ldflags="$ldflags" ./conode ./byzcoin/bcadmin ./eventlog/el ./scmgr 
 
 FROM debian:stretch-slim
+RUN apt update; apt install -y procps ca-certificates; apt clean
 WORKDIR /root/
-COPY --from=builder /go/bin/conode .
-COPY run_nodes.sh .
 RUN mkdir /conode_data
 RUN mkdir -p .local/share .config
 RUN ln -s /conode_data .local/share/conode
 RUN ln -s /conode_data .config/conode
+COPY --from=builder /go/bin/conode .
+COPY --from=builder /go/bin/bcadmin /go/bin/el /go/bin/scmgr /usr/local/bin/
 
 EXPOSE 7770 7771
 
-CMD "./run_nodes.sh -d /conode_data -v 2"
+CMD ["/root/conode", "-d", "2", "server"]

--- a/conode/Dockerfile
+++ b/conode/Dockerfile
@@ -11,9 +11,10 @@ RUN mkdir /conode_data
 RUN mkdir -p .local/share .config
 RUN ln -s /conode_data .local/share/conode
 RUN ln -s /conode_data .config/conode
+COPY run_nodes.sh .
 COPY --from=builder /go/bin/conode .
 COPY --from=builder /go/bin/bcadmin /go/bin/el /go/bin/scmgr /usr/local/bin/
 
 EXPOSE 7770 7771
 
-CMD ["/root/conode", "-d", "2", "server"]
+CMD ["./run_nodes.sh", "-d", "/conode_data", "-v", "2"]

--- a/conode/Dockerfile-dev
+++ b/conode/Dockerfile-dev
@@ -10,4 +10,4 @@ COPY exe/conode.Linux.x86_64 ./conode
 
 EXPOSE 7770 7771
 
-CMD ["./run_nodes.sh", "-n", "1"]
+CMD ["./run_nodes.sh", "-d", "/conode_data", "-v", "2"]

--- a/conode/Dockerfile-dev
+++ b/conode/Dockerfile-dev
@@ -1,12 +1,13 @@
-FROM golang:1.10
+FROM debian:stretch-slim
 WORKDIR /root/
-COPY exe/conode.Linux.x86_64 ./conode
-COPY run_nodes.sh .
 RUN mkdir /conode_data
 RUN mkdir -p .local/share .config
 RUN ln -s /conode_data .local/share/conode
 RUN ln -s /conode_data .config/conode
+RUN apt update; apt install -y procps ca-certificates; apt clean
+COPY run_nodes.sh .
+COPY exe/conode.Linux.x86_64 ./conode
 
 EXPOSE 7770 7771
 
-CMD "./run_nodes.sh -d /conode_data -v 2"
+CMD ["./run_nodes.sh", "-n", "1"]

--- a/conode/Makefile
+++ b/conode/Makefile
@@ -1,38 +1,48 @@
 CONTAINER = conode_template
 IMAGE_NAME = dedis/$(CONTAINER)
 DATA_DIR = $(shell pwd)/conode_data
-VERSION = dev
-OUTPUT_DIR = conode-$(VERSION)
-TAG = $(VERSION)-$(shell date +%y%m%d)
+GITUNTRACKEDCHANGES := $(shell git status --porcelain --untracked-files=no)
+TAG = dev-$(shell date +%y%m%d)
+GIT_TAG = $(shell git tag -l --points-at HEAD )
+ifneq ($(GIT_TAG),)
+  TAG = $(GIT_TAG)
+endif
+OUTPUT_DIR = conode-$(TAG)
 
 # -s -w are for smaller binaries
 # -X compiles the git tag into the binary
-ldflags=-s -w -X main.gitTag=$(TAG) -X github.com/dedis/onet.gitTag=$(TAG)
-flags=-ldflags="$(ldflags)"
+ldflags=-s -w -X main.gitTag=$(TAG)
 
 all: docker
 
 # Use this target to build from only published sources.
 docker: clean Dockerfile
-	BUILDFLAG=$(flags)
-	docker build -t $(IMAGE_NAME):$(TAG) --build-arg BUILDFLAG="$(ldflags)" .
-	docker tag $(IMAGE_NAME):$(TAG) $(IMAGE_NAME):$(VERSION)
+	@[ -z "$(BUILD_TAG)" ] && echo "Must specify BUILD_TAG." && exit 1 || true
+	docker build -t $(IMAGE_NAME):$(BUILD_TAG) --build-arg BUILD_TAG="$(BUILD_TAG)" --build-arg ldflags="$(ldflags)" .
+	docker tag $(IMAGE_NAME):$(BUILD_TAG) $(IMAGE_NAME):dev
 
 # Use this target to build from local source instead of from publish sources.
-docker_dev: clean Dockerfile-dev exe/conode.Linux.x86_64
+docker_dev: clean Dockerfile-dev verify exe/conode.Linux.x86_64
 	docker build -t $(IMAGE_NAME):$(TAG) -f Dockerfile-dev .
-	docker tag $(IMAGE_NAME):$(TAG) $(IMAGE_NAME):$(VERSION)
+	docker tag $(IMAGE_NAME):$(TAG) $(IMAGE_NAME):dev
+
+docker_push: docker
+	@[ -n "$(GITUNTRACKEDCHANGES)" ] && echo "Pushing dirty images not allowed." && exit 1 || true
+	docker push $(IMAGE_NAME):$(BUILD_TAG)
+
+docker_push_latest: docker_push
+	docker tag $(IMAGE_NAME):dev $(IMAGE_NAME):latest
 
 docker_setup:
 	mkdir -p $(DATA_DIR)
 	docker run -it --rm -p 7770-7771:7770-7771 --name $(CONTAINER) -v $(DATA_DIR):/conode_data \
-	    $(IMAGE_NAME):$(VERSION) ./conode setup
+	    $(IMAGE_NAME):dev ./conode setup
 
 docker_run:
 	if [ ! -f conode_data/private.toml ]; then make docker_setup; fi
 	mkdir -p $(DATA_DIR)
 	docker run -it --rm -p 7770-7771:7770-7771 --name $(CONTAINER) -v $(DATA_DIR):/conode_data \
-	    $(IMAGE_NAME):$(VERSION)
+	    $(IMAGE_NAME):dev
 
 docker_stop:
 	docker rm -f $(CONTAINER)
@@ -44,8 +54,27 @@ docker_clean:
 clean:
 	rm -rf exe $(OUTPUT_DIR)
 
+verify:
+	GO111MODULE=on go mod verify
+	@echo "Checking for replace in go.mod..."
+	@if GO111MODULE=on go list -m all | grep --quiet '=>'; then exit 1; fi
+
 # The suffix on conode exe is the result from: echo `uname -s`.`uname -m`
 # so that we can find the right one in the wrapper script.
 # This is in it's own rule because the Docker build needs it also.
 exe/conode.Linux.x86_64:
-	GO111MODULE=on GOOS=linux GOARCH=amd64 go build $(flags) -o $@
+	GO111MODULE=on GOOS=linux GOARCH=amd64 go build -ldflags="$(ldflags)" -o $@
+
+bindist: clean verify exe/conode.Linux.x86_64
+	rm -rf $(OUTPUT_DIR)
+	mkdir $(OUTPUT_DIR)
+	cp exe/conode.Linux.x86_64 $(OUTPUT_DIR)
+	GO111MODULE=on GOOS=darwin GOARCH=amd64 go build -ldflags="$(ldflags)" -o $(OUTPUT_DIR)/conode.Darwin.x86_64
+	GO111MODULE=on GOOS=freebsd GOARCH=amd64 go build -ldflags="$(ldflags)" -o $(OUTPUT_DIR)/conode.FreeBSD.amd64
+	GO111MODULE=on GOOS=windows GOARCH=amd64 go build -ldflags="$(ldflags)" -o $(OUTPUT_DIR)/conode.exe
+	echo "#!/bin/sh" > $(OUTPUT_DIR)/conode
+	echo "./conode.\`uname -s\`.\`uname -m\` \$$*" >> $(OUTPUT_DIR)/conode
+	chmod +x $(OUTPUT_DIR)/conode
+	LANG=C tar zcf $(OUTPUT_DIR).tar.gz $(OUTPUT_DIR)
+	rm -rf $(OUTPUT_DIR)
+	ls -l $(OUTPUT_DIR).tar.gz


### PR DESCRIPTION
* as per [Dockefile documentation](https://docs.docker.com/engine/reference/builder/#cmd), there is three forms for CMD
  * `["path-to-executable", "arg0", args...]` -> exec directly
  * `["args0", args...]` -> exec via entrypoint
  * `executable arg0 args...` -> run via shell
* currently, the `"executable arg0 args..."` really means that docker exec `sh -c '"executable arg0 args..."'` (notice the single and double quotes), which is not what's wanted
* here, I've decided to use the first form, recommanded by Docker
* also, syncing the base image used to run the code in Dockerfile-dev with the one from Dockerfile